### PR TITLE
q-show directive: restore relevant display style

### DIFF
--- a/src/core/directives.js
+++ b/src/core/directives.js
@@ -6,7 +6,15 @@ var PROP_REG = /^(.*)\.([\w\-]+)$/
 module.exports = {
     show: function (value) {
         var el = this.el;
-        if (value) el.style.display = 'block';
+        if (value) {
+            el.style.display = '';
+            
+            var display = el.currentStyle ? el.currentStyle.display : getComputedStyle(el, null).display;
+            
+            if (display === 'none') {
+                el.style.display = 'block';
+            }
+        }
         else el.style.display = 'none';
     },
     'class': function (value) {


### PR DESCRIPTION
__q-show__ directive should restore _display_ property to the most relevant CSS rule or the default value of the element.